### PR TITLE
Added missing "Times new Roman" font to build pipeline and projects

### DIFF
--- a/BasicUI_CocosSharp/BasicUI_CocosSharp/BasicUI_CocosSharp.csproj
+++ b/BasicUI_CocosSharp/BasicUI_CocosSharp/BasicUI_CocosSharp.csproj
@@ -192,6 +192,10 @@
       <Link>Content\sounds\Select.xnb</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\Content\bin\Windows\Times_New_Roman_9_Regular.xnb">
+      <Link>Content\Times_New_Roman_9_Regular.xnb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/BasicUI_MonoGame/BasicUI_MonoGame_Android/BasicUI_MonoGame_Android.csproj
+++ b/BasicUI_MonoGame/BasicUI_MonoGame_Android/BasicUI_MonoGame_Android.csproj
@@ -119,6 +119,10 @@
       <Link>Content\Select.xnb</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\Content\bin\Windows\Times_New_Roman_9_Regular.xnb">
+      <Link>Content\Times_New_Roman_9_Regular.xnb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\Values\Strings.xml" />

--- a/BasicUI_MonoGame/BasicUI_MonoGame_Linux/BasicUI_MonoGame_Linux.csproj
+++ b/BasicUI_MonoGame/BasicUI_MonoGame_Linux/BasicUI_MonoGame_Linux.csproj
@@ -145,6 +145,10 @@
       <Link>Content\Images\MonoGameLogo.xnb</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\Content\bin\Windows\Times_New_Roman_9_Regular.xnb">
+      <Link>Content\Times_New_Roman_9_Regular.xnb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="app.config" />
     <None Include="OpenTK.dll.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/BasicUI_MonoGame/BasicUI_MonoGame_OSX/BasicUI_MonoGame_OSX.csproj
+++ b/BasicUI_MonoGame/BasicUI_MonoGame_OSX/BasicUI_MonoGame_OSX.csproj
@@ -142,5 +142,9 @@
       <Link>Content\Select.xnb</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\Content\bin\Windows\Times_New_Roman_9_Regular.xnb">
+      <Link>Content\Times_New_Roman_9_Regular.xnb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/BasicUI_MonoGame/BasicUI_MonoGame_Win_Desktop/BasicUI_MonoGame_Win_Desktop.csproj
+++ b/BasicUI_MonoGame/BasicUI_MonoGame_Win_Desktop/BasicUI_MonoGame_Win_Desktop.csproj
@@ -125,6 +125,10 @@
       <Link>Content\Select.xnb</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\Content\bin\Windows\Times_New_Roman_9_Regular.xnb">
+      <Link>Content\Times_New_Roman_9_Regular.xnb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/BasicUI_MonoGame/BasicUI_MonoGame_iOS/BasicUI_MonoGame_iOS.csproj
+++ b/BasicUI_MonoGame/BasicUI_MonoGame_iOS/BasicUI_MonoGame_iOS.csproj
@@ -142,6 +142,9 @@
     <None Include="..\Content\bin\iOS\Select.xnb">
       <Link>Content\Select.xnb</Link>
     </None>
+	<None Include="..\Content\bin\Windows\Times_New_Roman_9_Regular.xnb">
+      <Link>Content\Times_New_Roman_9_Regular.xnb</Link>
+    </None>
     <None Include="monogameicon.png" />
     <None Include="Info.plist" />
     <None Include="packages.config" />

--- a/BasicUI_MonoGame/Content/Content.mgcb
+++ b/BasicUI_MonoGame/Content/Content.mgcb
@@ -77,3 +77,9 @@
 /processorParam:Quality=Best
 /build:Select.wav
 
+#begin Times_New_Roman_9_Regular.spritefont
+/importer:FontDescriptionImporter
+/processor:FontDescriptionProcessor
+/processorParam:TextureFormat=Compressed
+/build:Times_New_Roman_9_Regular.spritefont
+

--- a/BasicUI_MonoGame/Content/Times_New_Roman_9_Regular.spritefont
+++ b/BasicUI_MonoGame/Content/Times_New_Roman_9_Regular.spritefont
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<XnaContent xmlns:Graphics="Microsoft.Xna.Framework.Content.Pipeline.Graphics">
+  <Asset Type="Graphics:FontDescription">
+    <!-- Value replaced by generator -->
+    <FontName>Times New Roman</FontName>
+    <!-- Value replaced by generator -->
+    <Size>9</Size>
+    <Spacing>0</Spacing>
+    <UseKerning>true</UseKerning>
+    <!-- Value replaced by generator -->
+    <Style>Regular</Style>
+    <DefaultCharacter>*</DefaultCharacter>
+    <CharacterRegions>
+      <CharacterRegion>
+        <Start>&#32;</Start>
+        <End>&#383;</End>
+      </CharacterRegion>
+    </CharacterRegions>
+  </Asset>
+</XnaContent>


### PR DESCRIPTION
In the windows build, the example did not run because it could not load the "Time new roman size 9" asset. This commit addresses this, as well as for other platforms.
